### PR TITLE
Add migrations to release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.0.0'
+ruby '3.0.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.3.1'
@@ -26,7 +26,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.4.4', require: false
+gem 'bootsnap', '>= 1.7.3', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     bcrypt (3.1.16)
     benchmark (0.1.1)
     bindex (0.8.1)
-    bootsnap (1.7.2)
+    bootsnap (1.7.3)
       msgpack (~> 1.0)
     bootstrap (4.6.0)
       autoprefixer-rails (>= 9.1.0)
@@ -401,7 +401,7 @@ PLATFORMS
 
 DEPENDENCIES
   administrate!
-  bootsnap (>= 1.4.4)
+  bootsnap (>= 1.7.3)
   bootstrap (~> 4.5)
   byebug
   capybara (>= 3.26)
@@ -442,7 +442,7 @@ DEPENDENCIES
   whenever
 
 RUBY VERSION
-   ruby 3.0.0p0
+   ruby 3.0.1p64
 
 BUNDLED WITH
-   2.2.3
+   2.2.15

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
-web: rails server
-worker: sidekiq
+web: bin/rails server
+worker: bundle exec sidekiq
+release: bin/rails db:migrate


### PR DESCRIPTION
* Docker container for dev environment was upgraded to Ruby 3.0.1. So updated Gemfile ruby version.
* After that, I ran into https://github.com/Shopify/bootsnap/issues/353, so updated Bootsnap.
* Updated Profile to run migrations and to use bundler / binstubs